### PR TITLE
Update workflow job keys, so they can be picked up as status checks

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -13,7 +13,7 @@ on:
     - cron: '8 05 * * *'
 
 jobs:
-  build:
+  build-linux-wheels:
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,10 +24,8 @@ jobs:
       rust_build_directory: rust/pyrust_xlsxwriter
 
     steps:
-    - name: Checkout open-source repository
+    - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        repository: 'intel/metric-post-processor'
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/build-windows-wheels.yml
+++ b/.github/workflows/build-windows-wheels.yml
@@ -13,7 +13,7 @@ on:
     - cron: '8 05 * * *'
 
 jobs:
-  build:
+  build-windows-wheels:
     runs-on: windows-latest
 
     strategy:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 jobs:
-  build:
-    name: Build
+  trivy-scan:
+    name: Trivy Security Scan
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve clarity and align job names with their specific purposes. The changes primarily involve renaming jobs and simplifying repository checkout configurations across multiple workflow files.

### Workflow job renaming:

* [`.github/workflows/build-linux-wheels.yml`](diffhunk://#diff-d36715007fda81f6578eb38d467395efb3b6b4cb24356fc47842cd2a860b58d3L16-R16): Renamed the job from `build` to `build-linux-wheels` for better clarity and alignment with the workflow's purpose.
* [`.github/workflows/build-windows-wheels.yml`](diffhunk://#diff-c4e91027b3bf4a3b3394807b69083e6c0c0cf60f1afd53df7af3f1594cb19046L16-R16): Renamed the job from `build` to `build-windows-wheels` to match the workflow's focus on Windows wheels.
* [`.github/workflows/trivy-scan.yml`](diffhunk://#diff-d2f2b520bb7bfb36f97c6ec62a237288585d8f9d4301d9b31cb0c3dfad98f1c9L10-R11): Renamed the job from `build` to `trivy-scan` and updated its name to `Trivy Security Scan` to reflect its security scanning functionality.

### Repository checkout simplification:

* [`.github/workflows/build-linux-wheels.yml`](diffhunk://#diff-d36715007fda81f6578eb38d467395efb3b6b4cb24356fc47842cd2a860b58d3L27-L30): Simplified the checkout step by removing the specific repository configuration, making it more generic.