### PR TITLE
Add automated build support for python 3.14

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     env:
       rust_build_directory: rust/pyrust_xlsxwriter

--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     env:
       rust_build_directory: rust/pyrust_xlsxwriter

--- a/.github/workflows/build-windows-wheels.yml
+++ b/.github/workflows/build-windows-wheels.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     env:
       rust_build_directory: rust\pyrust_xlsxwriter

--- a/rust/pyrust_xlsxwriter/Cargo.toml
+++ b/rust/pyrust_xlsxwriter/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.25.0"
-rust_xlsxwriter = "0.87.0"
+rust_xlsxwriter = "0.89.0"
 csv = "1.3.1"
 tempfile = "3.20.0"

--- a/rust/pyrust_xlsxwriter/pyproject.toml
+++ b/rust/pyrust_xlsxwriter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyrust_xlsxwriter"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
This pull request updates Python and Rust dependencies to ensure compatibility with newer versions and improve functionality. The most important changes include adding support for Python 3.14, updating the `rust_xlsxwriter` dependency, and increasing the minimum required Python version to 3.10.

### Python version updates:

* [`.github/workflows/build-linux-wheels.yml`](diffhunk://#diff-d36715007fda81f6578eb38d467395efb3b6b4cb24356fc47842cd2a860b58d3L21-R21): Added Python 3.14 to the matrix of supported versions for Linux wheel builds.
* [`.github/workflows/build-windows-wheels.yml`](diffhunk://#diff-c4e91027b3bf4a3b3394807b69083e6c0c0cf60f1afd53df7af3f1594cb19046L21-R21): Added Python 3.14 to the matrix of supported versions for Windows wheel builds.

### Rust dependency update:

* [`rust/pyrust_xlsxwriter/Cargo.toml`](diffhunk://#diff-b6428724629f113ee5f4a8caabae5982fc284bda318bfc2c663812c7e6822d9eL12-R12): Updated the `rust_xlsxwriter` dependency from version 0.87.0 to 0.89.0 for improved features and bug fixes.

### Minimum Python version requirement:

* [`rust/pyrust_xlsxwriter/pyproject.toml`](diffhunk://#diff-88c30bc66b9ee065b87844448bbd372a7f0f11ea7b3ec80cb24009538c1b871aL7-R7): Increased the minimum required Python version from 3.8 to 3.10 to align with the latest compatibility requirements.