### PR TITLE
Set Token-Permissions to least privilege

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '8 05 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build-linux-wheels:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-windows-wheels.yml
+++ b/.github/workflows/build-windows-wheels.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '8 05 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build-windows-wheels:
     runs-on: windows-latest

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -6,10 +6,16 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   trivy-scan:
     name: Trivy Security Scan
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,6 +32,11 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy to generate SBOM (SPDX JSON)
         uses: aquasecurity/trivy-action@0.28.0


### PR DESCRIPTION
This pull request updates GitHub Actions workflow files to improve security and reporting. The main changes involve explicitly setting permissions for workflows and enhancing the Trivy security scan job to upload results to GitHub's Security tab.

**Workflow permission hardening:**

* Added explicit `permissions: contents: read` to the `build-linux-wheels.yml` and `build-windows-wheels.yml` workflows to limit token permissions for better security. [[1]](diffhunk://#diff-d36715007fda81f6578eb38d467395efb3b6b4cb24356fc47842cd2a860b58d3R15-R17) [[2]](diffhunk://#diff-c4e91027b3bf4a3b3394807b69083e6c0c0cf60f1afd53df7af3f1594cb19046R15-R17)
* In the `trivy-scan.yml` workflow, set `permissions: contents: read` at the workflow level and added `permissions: contents: read, security-events: write` at the job level to allow uploading security scan results.

**Security scan reporting:**

* Added a step to the `trivy-scan` job to upload Trivy scan results (`trivy-results.sarif`) to the GitHub Security tab using the `github/codeql-action/upload-sarif@v3` action, improving visibility of security issues.